### PR TITLE
Allow multiple connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ clean:
 
 test:
 	echo "Please visit http://localhost:1337."
-	docker run --rm --name proxy -e "HOST=google.com" -e "PORT=80" -p "1337:1337" "${IMAGE}"
+	docker run --rm --name proxy -e "HOST=google.com" -e "PORT=80" -e "IDLE_TIMEOUT=1m" -p "1337:1337" "${IMAGE}"

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ It is configured using the following environment variables:
 * `HOST`, the host to proxy to. e.g. google.com
 * `PORT`, the port to proxy to. e.g. 80
 * `LISTEN_PORT`, the port to listen for connections on. Default: 1337
+* `IDLE_TIMEOUT`, the amount of time to wait before shutting down. e.g. 7200s, 120m, 2h. Default: 60m (one hour)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,13 @@
 #! /bin/sh
 
-export HOST="${HOST}"
-export PORT="${PORT}"
-export LISTEN_PORT="${LISTEN_PORT:-1337}"
+HOST="${HOST}"
+PORT="${PORT}"
+LISTEN_PORT="${LISTEN_PORT:-1337}"
+IDLE_TIMEOUT="${IDLE_TIMEOUT:-60m}"
 
-exec -- nc -l -p "${LISTEN_PORT}" -c "nc '${HOST}' '${PORT}'"
+echo "Proxying port ${LISTEN_PORT} to ${HOST}:${PORT}..."
+
+nc -kl \
+   -p "${LISTEN_PORT}" \
+   -c "nc '${HOST}' '${PORT}'" \
+   -i "${IDLE_TIMEOUT}"


### PR DESCRIPTION
Allows multiple connections instead of shutting down after the first
one. The auto-cleanup feature is instead provided via a timeout,
defaulting to one hour.